### PR TITLE
🚀 Add support for file system sockets

### DIFF
--- a/sockfilter/address.py
+++ b/sockfilter/address.py
@@ -1,5 +1,23 @@
 __all__ = ['Address']
 
-import collections
 
-Address = collections.namedtuple('Address', ['host', 'port'])
+class Address(object):
+    def __init__(self, address):
+        self.path = None
+        self.host = None
+        self.port = None
+        if isinstance(address, basestring):
+            self.path = address
+        elif len(address) == 2:
+            self.host, self.port = address
+        else:
+            raise ValueError('Unexpected params for Address: {}'.format(address))
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, self.__class__) and
+            self.__dict__ == other.__dict__
+        )
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/sockfilter/fake.py
+++ b/sockfilter/fake.py
@@ -18,7 +18,7 @@ class Fake(object):
                 self._real_socket = real.socket__socket(*args, **kwargs)
 
             def connect(self, address):
-                a = Address(*address)
+                a = Address(address)
                 if not predicate(a):
                     raise SockFilterError(a)
                 self._real_socket.connect(address)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,3 @@
-Flask==0.10.1
-nose==1.3.3
-pyOpenSSL==0.14
-requests==2.3.0
+Flask==0.12.2
+nose==1.3.7
+requests[security]==2.18.1

--- a/tests/server/server.py
+++ b/tests/server/server.py
@@ -2,7 +2,6 @@ from contextlib import contextmanager
 from flask import Flask
 import functools
 from multiprocessing import Process
-from OpenSSL import SSL
 import os.path
 import time
 
@@ -33,10 +32,7 @@ def server(port, use_ssl=False):
 
 
 def ssl_context():
-    c = SSL.Context(SSL.SSLv23_METHOD)
-    c.use_privatekey_file(file('key.pem'))
-    c.use_certificate_file(file('cert.pem'))
-    return c
+    return (file('cert.pem'), file('key.pem'))
 
 
 def file(name):


### PR DESCRIPTION
Was trying to use sockfilter in a large django application that uses
SysLogHandler, https://hg.python.org/cpython/file/2.7/Lib/logging/handlers.py#l740

In that case, socket.connect() receives a string, so sockfilter was
throwing:
```
  File "/usr/lib/python2.7/logging/config.py", line 576, in configure
      '%r: %s' % (name, e))
      ValueError: Unable to configure handler 'somehandler': __new__()
      takes exactly 3 arguments (9 given)
```
This commit also includes some changes to tests to reflect some changes
with ssl in python.

#### Local Testing
```
➜ nosetests
..../Users/jonathanlafleche/workspace/sockfilter/venv/lib/python2.7/site-packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
....
----------------------------------------------------------------------
Ran 8 tests in 2.407s

OK
```